### PR TITLE
Sync Rails conditional asset templating

### DIFF
--- a/app/views/layouts/head/_scripts.html.erb
+++ b/app/views/layouts/head/_scripts.html.erb
@@ -1,12 +1,17 @@
-<!-- Scripts -->
-<%= javascript_include_tag 'application' %>
-<% if @ext_js.present?
-  Array.wrap(@ext_js).each do |js|
-    concat "  #{javascript_include_tag js}\n".html_safe
-  end
-end %>
-<% if @inline_js.present?
-  Array.wrap(@inline_js).each do |js|
-    concat "  <script>\n#{js}\n  </script>\n".html_safe
-  end
-end %>
+  <!-- Scripts -->
+  <%= javascript_include_tag 'application' %>
+  <% if @ext_js.present? || @inline_js.present? %>
+  <!-- Conditional -->
+  <% end %>
+  <% if @ext_js.present?
+    Array.wrap(@ext_js).each do |js| %>
+  <%= javascript_include_tag js %>
+    <% end
+  end %>
+  <% if @inline_js.present?
+    Array.wrap(@inline_js).each do |js| %>
+  <script>
+<%= js.html_safe %>
+  </script>
+    <% end
+  end %>

--- a/app/views/layouts/head/_stylesheets.html.erb
+++ b/app/views/layouts/head/_stylesheets.html.erb
@@ -1,12 +1,17 @@
-<!-- Stylesheets -->
-<%= stylesheet_link_tag 'application' %>
-<% if @ext_css.present?
-  Array.wrap(@ext_css).each do |css|
-    concat "  #{stylesheet_link_tag css}\n".html_safe
-  end
-end %>
-<% if @inline_css.present?
-  Array.wrap(@inline_css).each do |css|
-    concat "  <style>\n#{css}\n  </style>\n".html_safe
-  end
-end %>
+  <!-- Stylesheets -->
+  <%= stylesheet_link_tag 'application', media: nil %>
+  <% if @ext_css.present? || @inline_css.present? %>
+  <!-- Conditional -->
+  <% end %>
+  <% if @ext_css.present?
+    Array.wrap(@ext_css).each do |css| %>
+  <%= stylesheet_link_tag css, media: nil %>
+    <% end
+  end %>
+  <% if @inline_css.present?
+    Array.wrap(@inline_css).each do |css| %>
+  <style>
+<%= css.html_safe %>
+  </style>
+    <% end
+  end %>


### PR DESCRIPTION
Remove use of concat and use ERB output

Add "media: nil" option to stylesheet tag,
as Rails defaults to setting `media="screen"`
but browsers default to treating as `media="all"` without it

Add output of <!-- Conditional --> comment if conditional assets loaded

<%= stylesheet_link_tag ... %> and <%= javascript_include_tag ...%>
are indented awkwardly in the template source
to produce well-indented markup in page source