### PR TITLE
Fix search's "Relevancy" sort link

### DIFF
--- a/app/helpers/orchid/sort_helper.rb
+++ b/app/helpers/orchid/sort_helper.rb
@@ -14,7 +14,16 @@ module Orchid::SortHelper
 
   def sort type, direction="desc"
     new_params = copy_params
-    new_params["sort"] = ["#{type}|#{direction}"]
+
+    # If linking to sort by "score" (relevancy), send no sort[] parameter
+    if type == "score"
+      # sort type "score" results in an API error
+      new_params.delete("sort")
+    else
+      new_params["sort"] = ["#{type}|#{direction}"]
+    end
+
+    # If switching sort type or direction, start at first page of results
     new_params.delete("page")
     return new_params
   end


### PR DESCRIPTION
Remove sort param for Relevancy link;
sort param value of "score" results in API error

Add comments to explain sort_helper code

Close #22