### PR TITLE
Drop "action" and "controller" params from URLs

### DIFF
--- a/app/helpers/orchid/application_helper.rb
+++ b/app/helpers/orchid/application_helper.rb
@@ -1,7 +1,10 @@
 module Orchid::ApplicationHelper
 
   def copy_params
+    # Remove Rails internal parameters "action" and "controller" from URLs
+    # They are always accessible via params["action"] and params["controller"]
     return params.to_unsafe_h
+             .reject { |param| param[/^(?:action|controller)$/] }
   end
 
   def clear_search_text


### PR DESCRIPTION
Always accessible via `params["action"]` and `params["controller"]`