### PR TITLE
Add section class to <html>; Clear up helper use

### DIFF
--- a/app/helpers/orchid/application_helper.rb
+++ b/app/helpers/orchid/application_helper.rb
@@ -15,7 +15,7 @@ module Orchid::ApplicationHelper
       # Use override from instance variable
       section = @site_section
     else
-      if current_page?(home_path)
+      if current_page? home_path
         section = "home"
       elsif request.path[/^\/[^\/]+?\/.+/]
         # If request path has a sub-uri section (or namespacing),

--- a/app/helpers/orchid/application_helper.rb
+++ b/app/helpers/orchid/application_helper.rb
@@ -10,4 +10,29 @@ module Orchid::ApplicationHelper
     return new_params
   end
 
+  def site_section
+    if @site_section.present?
+      # Use override from instance variable
+      section = @site_section
+    else
+      if current_page?(home_path)
+        section = "home"
+      elsif request.path[/^\/[^\/]+?\/.+/]
+        # If request path has a sub-uri section (or namespacing),
+        # use that part of the path (e.g. "browse" of "/browse/creator")
+        section = request.path[/^\/([^\/]+?)\/.+/, 1]
+      else
+        # If path matches controller or action name, use that (e.g. "/about")
+        if request.path[/^\/#{params["controller"]}$/]
+          section = params["controller"]
+        elsif request.path[/^\/#{params["action"]}$/]
+          section = params["action"]
+        else
+          section = "pages"
+        end
+      end
+    end
+
+    return " class=\"site_#{section}\"".html_safe
+  end
 end

--- a/app/helpers/orchid/items_helper.rb
+++ b/app/helpers/orchid/items_helper.rb
@@ -1,7 +1,5 @@
 module Orchid::ItemsHelper
-  include Orchid::ApplicationHelper
-
-  # include the overridable versions of the helpers
+  # Include related helpers not auto-included by matching controller name
   include DateHelper
   include DisplayHelper
   include FacetHelper

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html<%= site_section %>>
   <%= render "layouts/head/head" %>
   <body>
     <div id="body-wrapper">

--- a/lib/generators/setup_generator.rb
+++ b/lib/generators/setup_generator.rb
@@ -28,6 +28,7 @@ class SetupGenerator < Rails::Generators::Base
     msgs << footer_logo
     msgs << gems
     msgs << gitignore
+    msgs << helpers
     msgs << remove_files
     msgs << scripts
     msgs << stylesheet
@@ -119,6 +120,13 @@ class SetupGenerator < Rails::Generators::Base
     FileUtils.cp("#{@this_app}/lib/generators/templates/.gitignore", "#{@new_app}/.gitignore")
 
     return "Orchid .gitignore file copied to app's root directory"
+  end
+
+  def helpers
+    FileUtils.rm("#{@new_app}/app/helpers/application_helper.rb")
+    FileUtils.cp(Dir.glob("#{@this_app}/app/helpers/*_helper.rb"), "#{@new_app}/app/helpers/")
+
+    return "Copied extendable helper files which include Orchid's to app"
   end
 
   def prompt_for_value(message, default)


### PR DESCRIPTION
Add class="site_(section)" to <html> element
Application helper site_section called from application layout view
Uses the first value from:
- Manual override in @site_section instance variable
- "home" if a request for the home page
- A sub-uri or namespace name in the path
- Path name if it matches the controller or action name
- "pages" as the last default

Change generator to copy extendable helper files to main app

Remove Orchid::ApplicationHelper include from Orchid::ItemsHelper as
included app-wide by application_helper.rb copied to main app

Close #15 