### PR TITLE
Clean up Orchid::Routing to work with Passenger

### DIFF
--- a/config/initializers/routes.rb
+++ b/config/initializers/routes.rb
@@ -1,0 +1,1 @@
+../routes.rb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
-# Run by lib/orchid/routing.rb so ROUTES defined when doing main app's routing
+# Symlinked from initializers/routes.rb so ROUTES defined for main app's routing
 # in case Orchid routes to be drawn before or between main app's
 # Run a second time automatically by Rails after main app's routing
 
 # For more information, please refer to the README's Configuration section
 
 module Orchid
-  class Routing
+  module Routing
     if !defined? ROUTES
       with_period = /[^\/]+/
 
@@ -44,9 +44,9 @@ module Orchid
           match '/500', to: 'errors#server_error', via: :all
         }}
       ]
+    else
+      # Draw routes second time this code is called for routing after main app's
+      draw
     end
-
-    # Draw routes second time this code is called for routing after main app's
-    draw if defined?(@@ready_to_draw)
   end
 end

--- a/lib/orchid/routing.rb
+++ b/lib/orchid/routing.rb
@@ -13,10 +13,6 @@ module Orchid
           # Add names reserved by main app for more general routes, e.g. '/:id'
           drawn_routes += reserved_names
 
-          # Handle apps with relative url root
-          url_prefix = Rails.application.config.relative_url_root.present? ?
-            Rails.application.config.relative_url_root : "/"
-
           ROUTES.each do |route|
             next if drawn_routes.include?(route[:name])
 

--- a/lib/orchid/routing.rb
+++ b/lib/orchid/routing.rb
@@ -1,41 +1,30 @@
-# Load routes into Orchid::Routing::ROUTES constant before main app's routing
-require_relative "../../config/routes"
-
 module Orchid
-  class Routing
+  module Routing
+    module_function
 
-    # Indicate draw method below available in routes.rb when run by Rails
-    @@ready_to_draw = true
+    def draw(reserved_names: [])
+      # Retrieve list of main app's route names
+      drawn_routes = defined?(Rails.application.routes) ?
+        Rails.application.routes.routes.map { |r| r.name } : []
 
-    # Only draw Orchid routes once: before, between, or after main app's routes
-    @@routes_drawn = false
-
-    def self.draw(reserved_names: [])
-      if !@@routes_drawn
+      # If home path drawn, assume Orchid's routes have already been drawn
+      if !drawn_routes.include?("home")
         Rails.application.routes.draw do
-          # Retrieve list of main app's route names
-          app_route_names = Rails.application.routes.routes.map { |r| r.name }
-
           # Add names reserved by main app for more general routes, e.g. '/:id'
-          app_route_names += reserved_names
+          drawn_routes += reserved_names
 
           # Handle apps with relative url root
           url_prefix = Rails.application.config.relative_url_root.present? ?
             Rails.application.config.relative_url_root : "/"
 
-          scope url_prefix do
-            ROUTES.each do |route|
-              next if app_route_names.include?(route[:name])
+          ROUTES.each do |route|
+            next if drawn_routes.include?(route[:name])
 
-              # Call routing DSL methods in Orchid route procs in this context
-              instance_eval(&route[:definition])
-            end
+            # Call routing DSL methods in Orchid route procs in this context
+            instance_eval(&route[:definition])
           end
-
-          @@routes_drawn = true
         end
       end
     end
-
   end
 end


### PR DESCRIPTION
Previous approach with `require_relative`, aside from feeling very hacky
and not the Rails way, breaks when deployed via Phusion Passenger
because of its smart spawning method to save resources
and speed up extra app process creation:
https://www.phusionpassenger.com/library/indepth/ruby/spawn_methods/

Symlink `config/routes.rb` from `config/initializers/` to properly load
`ROUTES` constant before main app's routing is processed

Remove class variables as they don't work well with Passenger smart
spawning either. Instead:
- Only call draw method from `routes.rb` if `ROUTES` defined
- Directly check drawn routes to determine whether Orchid should
draw its routes when draw method called

Check whether home path drawn, as apps will always need a home path
and its location should never change, though its controller and view
will often be overridden in the main app

Remove `scope url_prefix` which breaks routes when deployed
via Passenger, our preferred method of deploying Rails apps at sub-URIs

Change `Orchid::Routing` to a module since it is never instantiated

Use `module_function` scoping for draw method per style guide:
https://github.com/bbatsov/ruby-style-guide#module-function

Close #16