### PR TITLE
patches facet / filter link creation to work with semicolons

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -65,5 +65,19 @@ class ItemsController < ApplicationController
     end
   end
 
+  private
+
+  # methods to handle semicolons
+  def decode_filter(filter)
+    filter = filter.gsub("%3B", ";")
+    filter.gsub("%253B", ";")
+  end
+  helper_method :decode_filter
+
+  def encode_filter(filter)
+    filter.gsub(";", "%3B")
+  end
+  helper_method :encode_filter
+
 end
 

--- a/app/helpers/orchid/facet_helper.rb
+++ b/app/helpers/orchid/facet_helper.rb
@@ -8,7 +8,7 @@ module Orchid::FacetHelper
   end
 
   def create_label key, default="No Label"
-    return key ? key : default
+    return key ? decode_filter(key) : default
   end
 
   # type = "novel"
@@ -28,7 +28,7 @@ module Orchid::FacetHelper
       end
     end
     # verify that this exact facet has not already been added
-    facet_label = "#{type}|#{facet}"
+    facet_label = "#{type}|#{encode_filter(facet)}"
     if !new_params["f"].include?(facet_label)
       new_params["f"] << facet_label
     end
@@ -43,7 +43,7 @@ module Orchid::FacetHelper
   def facet_selected? type, facet=""
     if params["f"].present?
       if facet && facet.length > 0
-        return params["f"].include?("#{type}|#{facet}")
+        return params["f"].include?("#{type}|#{encode_filter(facet)}")
       else
         return params["f"].any? { |f| f.include?(type) }
       end
@@ -65,7 +65,7 @@ module Orchid::FacetHelper
   def remove_facet type, facet
     new_params = copy_params
     new_params.delete("page")
-    new_params["f"].delete("#{type}|#{facet}")
+    new_params["f"].delete("#{type}|#{encode_filter(facet)}")
     return new_params
   end
 

--- a/app/views/items/_facets.html.erb
+++ b/app/views/items/_facets.html.erb
@@ -25,7 +25,7 @@
           <ul class="list-unstyled">
             <% facet_res.each do |key, value| %>
               <% selected = facet_selected?(facet_name, key) %>
-              <% label = create_label key, "No Label" %>
+              <% label = create_label(key, "No Label") %>
 
               <!-- list item -->
               <% if !selected %>

--- a/app/views/items/_summary_boxes.html.erb
+++ b/app/views/items/_summary_boxes.html.erb
@@ -41,7 +41,7 @@
       <div class="pull-left form-inline buffer-bottom-sm buffer-right-sm">
         <div class="input-group">
           <div class="input-group-addon" title="<%= label %> Filter">
-            <%= label %> : <%= facet %>
+            <%= label %> : <%= decode_filter(facet) %>
           </div>
           <div class="input-group-btn" aria-label="Clear <%= label %> Filter" title="Clear <%= label %> Filter">
             <%= link_to search_path(remove_facet(type, facet)), class: "btn btn-default btn-sm", role: "button" do %>

--- a/app/views/items/browse_facet.html.erb
+++ b/app/views/items/browse_facet.html.erb
@@ -45,7 +45,7 @@
         <ul class="list-unstyled">
           <% @res[facet_name].each do |list| %>
             <li class="row">
-              <%= link_to search_path("f" => ["#{facet_name}|#{list[0]}"]) do %>
+              <%= link_to search_path("f" => ["#{facet_name}|#{encode_filter(list[0])}"]) do %>
                 <% text = list[0].blank? ? "No label" : list[0] %>
                 <div class="col-lg-5 col-md-6 col-sm-8 col-xs-10 browse-item">
                   <span><%= text %></span>

--- a/lib/orchid/version.rb
+++ b/lib/orchid/version.rb
@@ -1,7 +1,7 @@
 module Orchid
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 
   def self.api_bridge_version
-    'v0.0.2'
+    'v0.0.3'
   end
 end


### PR DESCRIPTION
believe that semicolons will be used beyond current project's demands
therefore implementing the fix in orchid itself
rails interprets semicolons as delineating a parameter, example:
`f[]=field|Cather; Pound` in form becomes
`f[]=field|Cather&Pound`
in order to address this problem, encoding urls, decoding for display text
pairs with changes made to api_bridge (0.0.3)

addresses problem described in https://github.com/Willa-Cather-Archive/letters-rails/issues/155