### PR TITLE
facet_sort and browse_sort separated

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,7 @@ class ItemsController < ApplicationController
     end
 
     sort_by = params["facet_sort"].present? ?
-      params["facet_sort"] : API_OPTS["facet_sort"]
+      params["facet_sort"] : API_OPTS["browse_sort"]
 
     # Get facet results
     @res = $api.query({"facet" => @browse_facet, "facet_num" => 10000,

--- a/lib/generators/templates/public.yml
+++ b/lib/generators/templates/public.yml
@@ -17,9 +17,11 @@ default: &default
     sort:
       - title|asc
     rows: 50
-    # facet info
+    # facet info on search page
     facet_limit: 20
     facet_sort: count|desc
+    # facet info on browse page
+    browse_sort: term|asc
     # highlighting
     hl_fl: annotations_text, transcription_t, text
     hl_num: 5


### PR DESCRIPTION
will allow different default orderings on browse
page and search results sidebar

closes https://github.com/CDRH/orchid/issues/61