### PR TITLE
locale parameter optional

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options
-    { locale: I18n.locale }
+    params["locale"] ? { locale: I18n.locale } : {}
   end
 
   if API_PATH


### PR DESCRIPTION
in sites which are not multilanguage, this is necessary to prevent
locale=en or /en/ from showing up in the URL when it is not
necessary