### PR TITLE
reworks orchid language handling to avoid multiple paths for same content

### DIFF
--- a/app/helpers/orchid/application_helper.rb
+++ b/app/helpers/orchid/application_helper.rb
@@ -92,6 +92,15 @@ module Orchid::ApplicationHelper
     I18n.locale
   end
 
+  def locale_link_options(lang_code)
+    # don't use copy_params because we still want the action and controller
+    opts = params.to_unsafe_h
+    # if the requested language is the default, then it needs to be blank
+    # but otherwise, fill in locale with the requested language
+    opts["locale"] = lang_code == APP_OPTS["language_default"] ? "" : lang_code
+    opts
+  end
+
   def localized_partial(partial_name, prefixes)
     localized = "#{partial_name}_#{locale}"
     if lookup_context.template_exists?(localized, prefixes, true)

--- a/app/helpers/orchid/application_helper.rb
+++ b/app/helpers/orchid/application_helper.rb
@@ -101,6 +101,13 @@ module Orchid::ApplicationHelper
     opts
   end
 
+  # partial_name does not include the locale, underscore, or extensions
+  #   (ex: index, not _index_en.html.erb)
+  # prefixes refers to the path to reach the partial in question
+  #
+  # Usage:
+  #   render localized_partial("index", "explore/partials")
+  #   (would include "explore/partials/_index_en.html.erb" if locale == en)
   def localized_partial(partial_name, prefixes)
     localized = "#{partial_name}_#{locale}"
     if lookup_context.template_exists?(localized, prefixes, true)

--- a/app/views/errors/_missing_partial.html.erb
+++ b/app/views/errors/_missing_partial.html.erb
@@ -1,1 +1,3 @@
-Partial for <%= locale %> was not found, please review your application's customization and add <%= "_#{@missing_partial}.html.erb" %>.
+<p>Partial for <%= locale %> was not found, please review your application's customization and add <%= "#{@missing_partial}.html.erb" %>.</p>
+
+<p>A common mistake is forgetting the _ underscore before a partial's name in the filesystem:  path/to/_partial.html.erb</p>

--- a/app/views/layouts/body/_languages.html.erb
+++ b/app/views/layouts/body/_languages.html.erb
@@ -1,18 +1,14 @@
-<% if APP_OPTS.key?("languages") %>
-  <% languages = APP_OPTS["languages"].split("|") %>
-  <% if languages.length > 1 %>
-    <div class="container language_selection">
-      Languages:
-      <% languages.each do |lang_code| %>
-        <% active = lang_code == I18n.locale.to_s ? "active" : "" %>
-        <span class="language_link">
-          <%= link_to lang_code.upcase, {
-            action: params["action"],
-            controller: params["controller"],
-            locale: lang_code
-          }, class: active, hreflang: lang_code, rel: "alternate" %>
-        </span>
-      <% end %>
-    </div>
-  <% end %>
+<% if APP_OPTS["languages"].present? %>
+  <div class="language_link btn-group" role="group" aria-label="language choice">
+    <% langs = APP_OPTS["languages"].split("|") %>
+    <%# add the default to the list of languages %>
+    <% langs << APP_OPTS["language_default"] %>
+    <% langs.each do |lang_code| %>
+      <% active = lang_code == I18n.locale.to_s ?
+        "btn btn-primary" : "btn btn-default" %>
+      <%# create link to switch languages that keeps current parameters %>
+      <%= link_to lang_code.upcase, locale_link_options(lang_code),
+          class: active, hreflang: lang_code, rel: "alternate" %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/layouts/head/_meta.html.erb
+++ b/app/views/layouts/head/_meta.html.erb
@@ -1,25 +1,24 @@
-<meta name="application-name" content="<%= t "general.project_shortname" %>">
+<meta name="application-name" content="<%= t "general.project_shortname" %>"/>
 
 <% if @description.present? %>
-  <meta name="description" content="<%= @description %>">
+  <meta name="description" content="<%= @description %>"/>
 <% end %>
 
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta charset="utf-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
 <%= csrf_meta_tags %>
 
 <%# links for alternate language pages %>
-<% if APP_OPTS.key?("languages") && APP_OPTS["languages"].length > 1 %>
-  <% APP_OPTS["languages"].split("|").each do |lang_code| %>
+<% if APP_OPTS["languages"].present? %>
+  <% langs = APP_OPTS["languages"].split("|") %>
+  <% langs << APP_OPTS["language_default"] if APP_OPTS["language_default"].present? %>
+  <% langs.each do |lang_code| %>
+    <%# if this is the currently selected language
+        then no alternative link is needed for it %>
     <% next if lang_code == I18n.locale.to_s %>
-    <% opts = {
-      action: params["action"],
-      controller: params["controller"],
-      locale: lang_code
-    }%>
-    <% url = url_for opts %>
+    <% url = url_for locale_link_options(lang_code) %>
     <link rel="alternate" hreflang="<%= lang_code %>" href="<%= url %>" />
   <% end %>
 

--- a/lib/generators/templates/public.yml
+++ b/lib/generators/templates/public.yml
@@ -4,8 +4,8 @@ default: &default
     version: 0.1.0
     # defaults to "en" (english) if no default language set
     language_default: en
-    # defaults to "en" if nothing passed in, pipe delineated values (en|es|de)
-    languages: en
+    # pipe delineated values (es|de) for all non-default languages
+    # languages:
     # for application title settings, please alter the files in config/locales
 
     # name of the appropriate directory in media server filesystem (project name)

--- a/lib/orchid/routing.rb
+++ b/lib/orchid/routing.rb
@@ -13,13 +13,23 @@ module Orchid
           # Add names reserved by main app for more general routes, e.g. '/:id'
           drawn_routes += reserved_names
 
+          # if app has specified multiple language support
+          # then they should be included as possible routes
+          # the default language should NOT be specified
+          # as it will not have a locale in the URL
           langs = APP_OPTS["languages"]
-          locales = langs ? Regexp.new(langs) : /en/
-
-          scope "(:locale)", locale: locales do
+          if langs.present?
+            locales = Regexp.new(langs)
+            scope "(:locale)", constraints: { locale: locales } do
+              ROUTES.each do |route|
+                next if drawn_routes.include?(route[:name])
+                # Call routing DSL methods in Orchid route procs in this context
+                instance_eval(&route[:definition])
+              end
+            end
+          else
             ROUTES.each do |route|
               next if drawn_routes.include?(route[:name])
-
               # Call routing DSL methods in Orchid route procs in this context
               instance_eval(&route[:definition])
             end


### PR DESCRIPTION
https://github.com/CDRH/family_letters/issues/28
- raised issue of being able to get to same page via 'search' and 'es/search'
- addressed issue here by using language_default has the base URL (no language added)
  and languages setting no longer lists ALL supported languages, but only
  those alternate languages (non-default)
- this will require minor changes to the configuration of existing apps
- this required changing how the routes are drawn because the constraint for languages cannot be blank
  even when the parameter is optional
- also changed meta and language toggle code to include default language among
  the other languages, since it had previously been listed there as well

https://github.com/CDRH/family_letters/issues/26
- now passing ALL parameters to language switching links instead of just
  controller and action, which means that search filters / query preserved
- this was not designed accommodate situations where a filter might only be
  available in a particular language but not in another, so it may need to be
  revisited if we ever have such a situation come up

https://github.com/CDRH/family_letters/blob/design/app/views/layouts/head/_meta.html.erb#L1
- closes meta tags which had been altered on family letters, removing need for override

https://github.com/CDRH/family_letters/blob/design/app/views/layouts/body/_languages.html.erb#L1
https://github.com/CDRH/family_letters/issues/8
- grabbed updated button arrangement from family letters
- I didn't actually see any CSS specific to the language controls in family letters?