### PR TITLE
supports translating API facet results with locale file

### DIFF
--- a/app/helpers/orchid/facet_helper.rb
+++ b/app/helpers/orchid/facet_helper.rb
@@ -74,4 +74,32 @@ module Orchid::FacetHelper
     return facet && info["display"] && facet.length > 0
   end
 
+  # the particular value of, for example, the "format" field may need
+  # to be displayed in another language based on the app settings
+  # so if "translate" is true on a field in the Facets configuration, then
+  # check for translations via locale files
+  # yml values need to be the exact field name at
+  #   facet_value.{field_name}.{value_name}
+  #   fields / values like person.role, "Postal Card" are stored
+  # in locales yml as person_role, Postal_Card
+  def value_label field, value
+    info = Facets.facet_info[field]
+    if info && info["translate"] == true
+      field_name = field.gsub(".", "_")
+      # if this is a list of values, we need to return a list as well
+      subs = /[\., ]/
+      if value.class == Array
+        value.map do |v|
+          v = v.gsub(subs, "_")
+          t "facet_value.#{field_name}.#{v}", default: v
+        end
+      else
+        value_name = value.gsub(subs, "_")
+        t "facet_value.#{field_name}.#{value_name}", default: value
+      end
+    else
+      value
+    end
+  end
+
 end

--- a/app/helpers/orchid/facet_helper.rb
+++ b/app/helpers/orchid/facet_helper.rb
@@ -84,7 +84,7 @@ module Orchid::FacetHelper
   # in locales yml as person_role, Postal_Card
   def value_label field, value
     info = Facets.facet_info[field]
-    if info && info["translate"] == true
+    if info && info["translate"]
       field_name = field.gsub(".", "_")
       # if this is a list of values, we need to return a list as well
       subs = /[\., ]/

--- a/app/models/facets.rb
+++ b/app/models/facets.rb
@@ -29,6 +29,33 @@
 #     "category" => { "label" => "Categoría", "display": false }
 #   }
 # }
+#
+# You may also need to translate the specific facet results being
+# returned by the API and not just the field's label
+# For example, the category field might return the values of 4 categories
+# If you need to translate these, add the optional boolean "translate":
+#
+# "es" => {
+#   "format" => {
+#     "label" => "Categoría",
+#     "display": true,
+#     "translate": true
+#   }
+# }
+#
+# You will then need to add the desired mappings to a locale file. You may add it
+# to the general [lang].yml file, or create your own [your_choice].yml.
+# Store the values at this path:
+#   facet_value.{field_name}.{value_name}
+#   fields / values like person.role, "Postal Card" should use underscores
+#   => person_role, Postal_Card
+#
+# es:
+#   facet_value:
+#     format:
+#       photograph: fotografía
+#       manuscript: manuscrito
+
 
 module Facets
   extend Orchid::Facets

--- a/app/views/items/_facets.html.erb
+++ b/app/views/items/_facets.html.erb
@@ -27,7 +27,10 @@
           <ul class="list-unstyled">
             <% facet_res.each do |key, value| %>
               <% selected = facet_selected?(facet_name, key) %>
-              <% label = create_label key, t("search.filters.no_label", default: "No Label") %>
+              <%# value_label translates language if necessary, create_label
+                  puts default label if empty %>
+              <% label = create_label value_label(facet_name, key),
+                  t("search.filters.no_label", default: "No Label") %>
 
               <!-- list item -->
               <% if !selected %>

--- a/app/views/items/_search_res_items.html.erb
+++ b/app/views/items/_search_res_items.html.erb
@@ -26,7 +26,8 @@
             <% if item["format"] %>
               <li>
                 <strong><%= t "search.results.item.format", default: "Format" %></strong>:
-                <%= link_to item["format"], search_path({ "f[]" => "format|#{item['format']}" }),
+                <% label = value_label("format", item["format"]) %>
+                <%= link_to label, search_path({ "f[]" => "format|#{item['format']}" }),
                       rel: "nofollow" %>
               </li>
             <% end %>

--- a/app/views/items/browse_facet.html.erb
+++ b/app/views/items/browse_facet.html.erb
@@ -46,7 +46,7 @@
           <tbody>
             <% @res[facet_name].each do |list| %>
               <tr>
-                  <% text = list[0].blank? ? t("browse.no_label", default: "No label") : list[0] %>
+                  <% text = list[0].blank? ? t("browse.no_label", default: "No label") : value_label(facet_name, list[0]) %>
                   <td class="index_num">
                     <%= link_to search_path("f" => ["#{facet_name}|#{list[0]}"]), rel: "nofollow" do %>
                       <%= list[1] %>


### PR DESCRIPTION
if particular facet field specifies `"translate": true`, then that facet's
individual results should be translated based on the locale yml file values
has not been tested with any facets that contain special characters