### PR TITLE
Add item-specific 404 page, overrideable template

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -75,6 +75,10 @@ class ItemsController < ApplicationController
       url = @res["uri_html"]
       @html = Net::HTTP.get(URI.parse(url)) if url
       @title = item_title
+    else
+      @title = t "item.no_item", id: params["id"],
+        default: "No item with identifier #{params["id"]} found!"
+      render "show_not_found", status: 404
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,14 +1,3 @@
-<% if @res %>
-
-  <h2><%= @res["title"] %></h2>
-  <%= render "show_metadata" %>
-  <%= render "show_content" %>
-
-<% else %>
-
-  <h2><%= t("item.not_found", default: "Not Found") %></h2>
-  <%= t "item.no_item", id: params["id"], default: "No item with identifier #{params["id"]} found!" %>
-
-<% end %>
-
-
+<h2><%= @res["title"] %></h2>
+<%= render "show_metadata" %>
+<%= render "show_content" %>

--- a/app/views/items/show_not_found.html.erb
+++ b/app/views/items/show_not_found.html.erb
@@ -1,0 +1,12 @@
+<div class="row">
+  <div class="col-md-6">
+    <h2>
+      <%= t "item.no_item", id: params["id"], default: "No item with identifier
+        #{params["id"]} found!" %>
+    </h2>
+  </div>
+  <div class="col-md-6">
+    <%# This is here to be customized for specialized 404 pages %>
+    <%#= image_tag "404.png" %>
+  </div>
+</div>


### PR DESCRIPTION
Use i18n strings

Leave image tag commented in template for copying to customize for
specialized 404 pages

Close #131 