### PR TITLE
Sections Improvement

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,11 +1,11 @@
 class ErrorsController < ApplicationController
 
   def not_found
-    render_overridable(status: 404)
+    render(status: 404)
   end
 
   def server_error
-    render_overridable(status: 500)
+    render(status: 500)
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,21 @@
 
 module Orchid
   module Routing
-    if !defined? ROUTES
+    if !defined?(ROUTES)
       with_period = /[^\/]+/
 
+      # Routes only drawn once
       ROUTES = [
+        # Errors
+        { name: 'not_found', definition: proc {
+          match '/404', to: 'errors#not_found', via: :all, as: "not_found"
+        }},
+        { name: 'server_error', definition: proc {
+          match '/500', to: 'errors#server_error', via: :all, as: "server_error"
+        }}
+      ]
+
+      REUSABLE_ROUTES = [
         # Home
         { name: 'home', definition: proc { |section|
           section += "_" if section.present?
@@ -45,14 +56,6 @@ module Orchid
           section += "_" if section.present?
           get 'search', to: 'items#index', as: "#{section}search",
             defaults: { section: section }
-        }},
-
-        # Errors
-        { name: 'not_found', definition: proc {
-          match '/404', to: 'errors#not_found', via: :all
-        }},
-        { name: 'server_error', definition: proc {
-          match '/500', to: 'errors#server_error', via: :all
         }}
       ]
     else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,40 +22,29 @@ module Orchid
 
       REUSABLE_ROUTES = [
         # Home
-        { name: 'home', definition: proc { |section|
-          section += "_" if section.present?
-          root 'general#index', as: "#{section}home",
-            defaults: { section: section }
+        { name: 'home', definition: proc {
+          root 'general#index', as: "home"
         }},
 
         # General
-        { name: 'about', definition: proc { |section|
-          section += "_" if section.present?
-          get 'about', to: 'general#about', as: "#{section}about",
-            defaults: { section: section }
+        { name: 'about', definition: proc {
+          get 'about', to: 'general#about', as: "about"
         }},
 
         # Items
-        { name: 'browse', definition: proc { |section|
-          section += "_" if section.present?
-          get 'browse', to: 'items#browse', as: "#{section}browse",
-            defaults: { section: section }
+        { name: 'browse', definition: proc {
+          get 'browse', to: 'items#browse', as: "browse"
         }},
-        { name: 'browse_facet', definition: proc { |section|
-          section += "_" if section.present?
-          get 'browse/:facet', to: 'items#browse_facet',
-            as: "#{section}browse_facet", constraints: { facet: with_period },
-            defaults: { section: section }
+        { name: 'browse_facet', definition: proc {
+          get 'browse/:facet', to: 'items#browse_facet', as: "browse_facet",
+            constraints: { facet: with_period }
         }},
-        { name: 'item', definition: proc { |section|
-          section += "_" if section.present?
-          get 'item/:id', to: 'items#show', as: "#{section}item",
-            constraints: { id: with_period }, defaults: { section: section }
+        { name: 'item', definition: proc {
+          get 'item/:id', to: 'items#show', as: "item",
+            constraints: { id: with_period }
         }},
-        { name: 'search', definition: proc { |section|
-          section += "_" if section.present?
-          get 'search', to: 'items#index', as: "#{section}search",
-            defaults: { section: section }
+        { name: 'search', definition: proc {
+          get 'search', to: 'items#index', as: "search"
         }}
       ]
     else

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ Orchid is a generator which can be used to create a new CDRH API template site. 
     - [Section Config](#section-config)
     - [Section Routes](#section-routes)
     - [Section Links](#section-links)
-    - [Section-compatible Orchid Code](#section-compatible-orchid-code)
+    - [Section Templates](#section-templates)
   - [Stylesheets / Bootstrap](#stylesheets--bootstrap)
   - [(Re)start](#restart)
 - [Assets](#assets)
@@ -594,24 +594,7 @@ all following parameters are the same parameters to be sent to the path helper.
 <%= link_to prefix_path("item_path", "ABC"), html_options %>
 ```
 
-#### Section-compatible Orchid Code
-To make Orchid routes compatible with sections, the `section` parameter must be
-set at the beginning of the `proc` for the route definition. This `section`
-parameter will be the section name set in the main app routes file. Then if a
-section is present it needs an underscore appended. The route name must now be
-written with the section name prepended. Lastly, the section name needs to
-be available to the controllers and actions called by the route. This is done by
-setting the name as a default parameter named `section`. The resulting
-section-compatible Orchid route looks like this:
-
-```ruby
-{ name: 'item', definition: proc { |section|
-  section += "_" if section.present?
-  get 'item/:id', to: 'items#show', as: "#{section}item",
-    constraints: { id: with_period }, defaults: { section: section }
-}},
-```
-
+#### Section Templates
 Orchid's views and partials are made section-compatible by calling them with
 the `render_overridable` method rather than `render`. The exact same parameters
 one would use with `render` are available. This replacement method checks for

--- a/lib/orchid/routing.rb
+++ b/lib/orchid/routing.rb
@@ -36,9 +36,10 @@ module Orchid
       Rails.application.routes.draw do
         # Set scope to section name if no scope set
         scope = "/#{section}" if section.present? && scope.blank?
+        scope_path = scope
 
-        if scope.present?
-          scope scope, as: section, defaults: { section: section } do
+        if scope_path.present?
+          scope scope_path, as: section, defaults: { section: section } do
             instance_eval(&draw_reusable_routes)
           end
         else


### PR DESCRIPTION
Separate reusable routes; Refactor routing code
- Reusable routes moved to a separate array
- Error routes given path helper names
- Error actions reverted to use `render`
- Routing loops and route skipping de-duplicated
- Draw non-reusable routes after others with i18n support
- Revise comments

Simplify prefix and default params for routes
- Refactor routing code to use built-in `scope ..., as: "name"` for
  prefixing path helper names rather than Red Green approach
- Remove extra code from REUSABLE_ROUTES procs
- DRY up routing code even further by consolidating i18n route draws
- Update documentation to remove Red Green approach instructions
    - Rename header to "Section Templates"