### PR TITLE
major metadata helper overhaul

### DIFF
--- a/app/helpers/orchid/display_helper.rb
+++ b/app/helpers/orchid/display_helper.rb
@@ -17,7 +17,7 @@ module Orchid::DisplayHelper
       dataArray = data.map do |item|
         link ? metadata_create_field_link(api_field, item) : item
       end
-      html += dataArray
+      html << dataArray
                 .map { |i| "<span>#{i}</span>" }
                 .join(separator)
 

--- a/app/helpers/orchid/display_helper.rb
+++ b/app/helpers/orchid/display_helper.rb
@@ -5,23 +5,54 @@ module Orchid::DisplayHelper
   # link: whether or not text or a link to search results
   #       for the given filter will be displayed, defaults
   #       to displaying a link
-  def metadata(res, label, api_field, link: true)
-    data = res[api_field]
+  # separator: the characters used to distinguish between items
+  #       in a list, defaults to " | "
+  def metadata(res, label, api_field, link: true, separator: " | ")
+    data = metadata_get_field_values(res, api_field)
+
     if data.present?
-      html = "<li><strong>#{label}:</strong> "
-      dataArray = Array(data).map do |item|
-        if link
-          search_params = { "f" => ["#{api_field}|#{item}"] }
-          item_label = value_label(api_field, item)
-          link_to item_label, prefix_path("search_path", search_params),
-            rel: "nofollow"
-        else
-          item
-        end
+      html = metadata_label(label, data.length)
+
+      # iterate through the field values
+      dataArray = data.map do |item|
+        link ? metadata_create_field_link(api_field, item) : item
       end
-      html += dataArray.join(" | ")
-      return html.html_safe
+      html += dataArray
+                .map { |i| "<span>#{i}</span>" }
+                .join(separator)
+
+      sanitize html
     end
+  end
+
+  # put together a search path with an f[] parameter
+  #   example: ?f[]=category|Writings
+  def metadata_create_field_link(api_field, item)
+    search_params = { "f" => ["#{api_field}|#{item}"] }
+    item_label = value_label(api_field, item)
+    link_to item_label, prefix_path("search_path", search_params),
+      rel: "nofollow"
+  end
+
+  # regardless of whether the results are a simple array or an array
+  # of hashes (a nested field), return a list of the values
+  def metadata_get_field_values(res, api_field)
+    # only nested fields use "." in their name
+    if api_field.include?(".")
+      nested = api_field.split(".")
+      # fields are only nested one level deep
+      res[nested.first].map { |doc| doc[nested[1]] }
+    else
+      Array(res[api_field])
+    end
+  end
+
+  # metadata label has been separated to allow apps to override included HTML
+  #   length is not currently used but is predicted to be used, or could
+  #   be used by overriding applications if desired
+  def metadata_label(label, length)
+    # TODO potentially add pluralization by locale
+    "<strong>#{label}:</strong> "
   end
 
 end

--- a/app/helpers/orchid/display_helper.rb
+++ b/app/helpers/orchid/display_helper.rb
@@ -11,7 +11,7 @@ module Orchid::DisplayHelper
     data = metadata_get_field_values(res, api_field)
 
     if data.present?
-      html = metadata_label(label, data.length)
+      html = metadata_label(label, length: data.length)
 
       # iterate through the field values
       dataArray = data.map do |item|
@@ -48,10 +48,10 @@ module Orchid::DisplayHelper
   end
 
   # metadata label has been separated to allow apps to override included HTML
-  #   length is not currently used but is predicted to be used, or could
-  #   be used by overriding applications if desired
-  def metadata_label(label, length)
-    # TODO potentially add pluralization by locale
+  #   length intended to be used for pluralization,
+  #   or could be used by overriding applications if desired
+  def metadata_label(label, length: nil)
+    # TODO add pluralization that uses locale
     "<strong>#{label}:</strong> "
   end
 

--- a/app/views/items/_search_res_items.html.erb
+++ b/app/views/items/_search_res_items.html.erb
@@ -7,49 +7,25 @@
           <ul>
             <% if item["date_display"].present? %>
               <li>
-                <strong><%= t "search.results.item.date", default: "Date" %></strong>:
-                <span><%= item["date_display"] %></span>
+                <%= metadata(item, t("search.results.item.date", default: "Date"), "date_display", link: false) %>
               </li>
             <% end %>
             <%# creator is a multivalued, nested field %>
             <% if item["creator"].present? %>
               <li>
-                <strong>
-                  <%= t "search.results.item.creator", default: "Creator(s)" %>
-                </strong>:
-                <% item["creator"].each do |c| %>
-                  <span><%= c["name"] %></span>
-                <% end %>
+                <%= metadata(item, t("search.results.item.creator", default: "Creator"), "creator.name", link: false) %>
               </li>
             <% end %>
             <%# format can be a multivalued or single keyword field %>
             <% if item["format"].present? %>
               <li>
-                <strong>
-                  <%= t "search.results.item.format", default: "Format" %>
-                </strong>:
-                <% if item["format"].is_a? Array %>
-                  <% item["format"].each do |f| %>
-                    <span><%= value_label("format", f) %></span>
-                  <% end %>
-                <% else %>
-                  <span><%= value_label("format", item["format"]) %>
-                <% end %>
+                <%= metadata(item, t("search.results.item.format", default: "Format"), "format", link: false) %>
               </li>
             <% end %>
             <%# source can be a multivalued or single keyword field %>
             <% if item["source"].present? %>
               <li>
-                <strong>
-                  <%= t "search.results.item.source", default: "Source" %>
-                </strong>:
-                <% if item["source"].is_a? Array %>
-                  <% item["source"].each do |s| %>
-                    <span><%= s %></span>
-                  <% end %>
-                <% else %>
-                  <span><%= item["source"] %></span>
-                <% end %>
+                <%= metadata(item, t("search.results.item.source", default: "Source"), "source", link: false) %>
               </li>
             <% end %>
           </ul>

--- a/app/views/items/_search_res_items.html.erb
+++ b/app/views/items/_search_res_items.html.erb
@@ -7,25 +7,29 @@
           <ul>
             <% if item["date_display"].present? %>
               <li>
-                <%= metadata(item, t("search.results.item.date", default: "Date"), "date_display", link: false) %>
+                <%= metadata(item, t("search.results.item.date",
+                  default: "Date"), "date_display", link: false) %>
               </li>
             <% end %>
             <%# creator is a multivalued, nested field %>
             <% if item["creator"].present? %>
               <li>
-                <%= metadata(item, t("search.results.item.creator", default: "Creator"), "creator.name", link: false) %>
+                <%= metadata(item, t("search.results.item.creator",
+                  default: "Creator"), "creator.name", link: false) %>
               </li>
             <% end %>
             <%# format can be a multivalued or single keyword field %>
             <% if item["format"].present? %>
               <li>
-                <%= metadata(item, t("search.results.item.format", default: "Format"), "format", link: false) %>
+                <%= metadata(item, t("search.results.item.format",
+                  default: "Format"), "format", link: false) %>
               </li>
             <% end %>
             <%# source can be a multivalued or single keyword field %>
             <% if item["source"].present? %>
               <li>
-                <%= metadata(item, t("search.results.item.source", default: "Source"), "source", link: false) %>
+                <%= metadata(item, t("search.results.item.source",
+                  default: "Source"), "source", link: false) %>
               </li>
             <% end %>
           </ul>

--- a/app/views/items/_show_metadata.html.erb
+++ b/app/views/items/_show_metadata.html.erb
@@ -9,43 +9,43 @@
     <% if @res["date_display"].present? %>
       <li>
         <%= metadata(@res, t("item.metadata.date", default: "Date"),
-            "date_display") %>
+                     "date_display") %>
       </li>
     <% end %>
     <% if @res["creator"].present? %>
       <li>
         <%= metadata(@res, t("item.metadata.creators", default: "Author(s)"),
-            "creator.name") %>
+                     "creator.name") %>
       </li>
     <% end %>
     <% if @res["format"].present? %>
       <li>
         <%= metadata(@res, t("item.metadata.format", default: "Format"),
-            "format") %>
+                     "format") %>
       </li>
     <% end %>
     <% if @res["category"].present? %>
       <li>
         <%= metadata(@res, t("item.metadata.category", default: "Category"),
-            "category") %>
+                     "category") %>
       </li>
     <% end %>
     <% if @res["subcategory"].present? %>
       <li>
-        <%= metadata(@res, t("item.metadata.subcategory", default: "Subcategory"),
-            "subcategory") %>
+        <%= metadata(@res, t("item.metadata.subcategory",
+                     default: "Subcategory"), "subcategory") %>
       </li>
     <% end %>
     <% if @res["works"].present? %>
       <li>
         <%= metadata(@res, t("item.metadata.works", default: "Works"),
-            "works") %>
+                     "works") %>
       </li>
     <% end %>
     <% if @res["places"].present? %>
       <li>
         <%= metadata(@res, t("item.metadata.places", default: "Place(s)"),
-            "places") %>
+                     "places") %>
       </li>
     <% end %>
     <%# When copying this template into projects, consider adding rel tag to the source link

--- a/app/views/items/_show_metadata.html.erb
+++ b/app/views/items/_show_metadata.html.erb
@@ -1,19 +1,59 @@
 <div class="metadata">
   <ul>
-    <%= metadata @res, t("item.metadata.title", default: "Title"), "title", link: false %>
-    <%= metadata @res, t("item.metadata.date", default: "Date"), "date_display" %>
-    <%= metadata @res, t("item.metadata.creators", default: "Author(s)"), "creators" %>
-    <%= metadata @res, t("item.metadata.format", default: "Format"), "format" %>
-    <%= metadata @res, t("item.metadata.category", default: "Category"), "category" %>
-    <%= metadata @res, t("item.metadata.subcategory", default: "Subcategory"), "subcategory" %>
-    <%= metadata @res, t("item.metadata.works", default: "Works"), "works" %>
-    <%= metadata @res, t("item.metadata.places", default: "Place(s)"), "places" %>
+    <% if @res["title"].present? %>
+      <li>
+        <%= metadata(@res, t("item.metadata.title", default: "Title"),
+          "title", link: false) %>
+      </li>
+    <% end %>
+    <% if @res["date_display"].present? %>
+      <li>
+        <%= metadata(@res, t("item.metadata.date", default: "Date"),
+            "date_display") %>
+      </li>
+    <% end %>
+    <% if @res["creator"].present? %>
+      <li>
+        <%= metadata(@res, t("item.metadata.creators", default: "Author(s)"),
+            "creator.name") %>
+      </li>
+    <% end %>
+    <% if @res["format"].present? %>
+      <li>
+        <%= metadata(@res, t("item.metadata.format", default: "Format"),
+            "format") %>
+      </li>
+    <% end %>
+    <% if @res["category"].present? %>
+      <li>
+        <%= metadata(@res, t("item.metadata.category", default: "Category"),
+            "category") %>
+      </li>
+    <% end %>
+    <% if @res["subcategory"].present? %>
+      <li>
+        <%= metadata(@res, t("item.metadata.subcategory", default: "Subcategory"),
+            "subcategory") %>
+      </li>
+    <% end %>
+    <% if @res["works"].present? %>
+      <li>
+        <%= metadata(@res, t("item.metadata.works", default: "Works"),
+            "works") %>
+      </li>
+    <% end %>
+    <% if @res["places"].present? %>
+      <li>
+        <%= metadata(@res, t("item.metadata.places", default: "Place(s)"),
+            "places") %>
+      </li>
+    <% end %>
     <%# When copying this template into projects, consider adding rel tag to the source link
-        to note the format and if the link is external %>
+    to note the format and if the link is external %>
     <% if @res["uri_data"].present? %>
-        <li><strong>Source Document: </strong>
-            <a href="<%= @res["uri_data"] %>"><%= File.basename(@res["uri_data"]) %></a>
-        </li>
+    <li><strong>Source Document: </strong>
+      <a href="<%= @res["uri_data"] %>"><%= File.basename(@res["uri_data"]) %></a>
+    </li>
     <% end %>
   </ul>
 </div>


### PR DESCRIPTION
moved <li> out of metadata method and into views
  makes it easier to override if called somewhere besides a <ul>, etc
  but this does mean checking if field is present? before using
added support for nested fields
split into multiple methods instead of a big'n
pulled metadata_label into its own method for easier overriding
  also preemptively built "length" into method arguments for future work
now search item response AND item show pages use same method for building metadata