### PR TITLE
render overridable applied for general pages

### DIFF
--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -1,8 +1,10 @@
 class GeneralController < ApplicationController
   def about
     @title = t "about.title"
+    render_overridable("general", "about")
   end
 
   def index
+    render_overridable("general", "index")
   end
 end


### PR DESCRIPTION
already was implemented for item pages, but has become
clear after use that we will want it for the (section)
home and about pages as well