### PR TITLE
fixes non-linked translations of metadata

### DIFF
--- a/app/helpers/orchid/display_helper.rb
+++ b/app/helpers/orchid/display_helper.rb
@@ -15,7 +15,11 @@ module Orchid::DisplayHelper
 
       # iterate through the field values
       dataArray = data.map do |item|
-        link ? metadata_create_field_link(api_field, item) : item
+        if link
+          metadata_create_field_link(api_field, item)
+        else
+          value_label(api_field, item)
+        end
       end
       html << dataArray
                 .map { |i| "<span>#{i}</span>" }


### PR DESCRIPTION
regardless of whether or not something is a link,
we want to display the appropriate language value!