### PR TITLE
fixes pagination bug where page 2 of search errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- bug with search pagination
+
 ## [v3.0.2](https://github.com/CDRH/orchid/compare/v3.0.1...v3.0.2) - html_classes for styling and minor fixes
 
 ### Added

--- a/app/views/items/_paginator.html.erb
+++ b/app/views/items/_paginator.html.erb
@@ -31,7 +31,7 @@
                     rel: "nofollow", "aria-label": "First Page" %>
       </li>
       <%# don't display dots between 1 and 2 %>
-      <% if pages_prior.min > 2 %>
+      <% if pages_prior.present? && pages_prior.min > 2 %>
         <li class="disabled"><span aria-label="Jump in interval">…</span></li>
       <% end %>
     <% end %>


### PR DESCRIPTION
I'm guessing this was introduced here:
https://github.com/CDRH/orchid/commit/4079e0067b6129789300c869c1702169280c1623
but I am impressed we didn't notice until now

as one might expect, if there are no prior pages then it should not be displaying the minimum (nonexistent) prior page