### PR TITLE
fixes bug with paginating results of exactly two pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- bug with search pagination when small result set
+
 ## [v3.0.3](https://github.com/CDRH/orchid/compare/v3.0.2...v3.0.3) - pagination bugfix
 
 ### Fixed

--- a/app/helpers/orchid/pagination_helper.rb
+++ b/app/helpers/orchid/pagination_helper.rb
@@ -6,7 +6,7 @@ module Orchid::PaginationHelper
     if total > 1
       current = valid_page
       pages_prior = (current-display_range..current-1).reject { |x| x <= 1 }
-      pages_next = (current+1..current+display_range).reject { |x| x >= total }
+      pages_next = (current+1..current+display_range).reject { |x| x > total }
 
       render_overridable("paginator",
         current: current,

--- a/app/views/items/_paginator.html.erb
+++ b/app/views/items/_paginator.html.erb
@@ -59,7 +59,7 @@
 
     <%# add dots if necessary %>
     <% if current != total %>
-      <% if pages_next.max != total-1 && current != total-1 %>
+      <% if pages_next.max != total && current != total-1 %>
         <li class="disabled"><span aria-label="Jump in interval">…</span></li>
       <% end %>
       <%# do not display the last page to prevent users from jumping


### PR DESCRIPTION
the issue was that if you had a 2 page search result,
the second page was not displaying because the "last" page was
not in the list of next pages, and the last page is also no longer
available by default

fixed by adding the total page number to the pages_next
and make sure to display dots if there are more results after
the current range max page