### PR TITLE
Route path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - `render_overridable` calls with full path to partials
+- `"search_path"` changed to `route_path` to allow overrides
 
 ### Migration
 - check overridden partials / views for `render_overridable` calls without

--- a/app/views/items/_clear_facets.html.erb
+++ b/app/views/items/_clear_facets.html.erb
@@ -1,6 +1,6 @@
 <% if params["f"].present? || date_selection?(params["date_from"], params["date_to"]) %>
   <div class="pull-right buffer-bottom-sm">
-    <%= link_to prefix_path("search_path", { q: params["q"] }),
+    <%= link_to prefix_path(route_path, { q: params["q"] }),
       class: "btn btn-default btn-sm", rel: "nofollow" do %>
       <%= t "search.filters.clear_all", default: "Clear Filters" %>
       <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>

--- a/app/views/items/_date_limit.html.erb
+++ b/app/views/items/_date_limit.html.erb
@@ -10,14 +10,14 @@
     <span class="pull-right glyphicon <%= class_glyphicon %>" aria-hidden="true"></span>
   </div>
   <div class="panel-body collapse <%= class_in %>" id="dates">
-    <%= form_tag prefix_path("search_path"), method: "get" do %>
+    <%= form_tag prefix_path(route_path), method: "get" do %>
       <%# date from %>
       <div class="form-group form-inline">
         <% dfrom = params["date_from"] ? params["date_from"] : [] %>
         <div class="clearfix">
           <%= label_tag "date_from", t("search.dates.date_from_label", default: "Date From") %>
           <% if date_selection?(params["date_from"], params["date_to"]) %>
-            <%= link_to prefix_path("search_path", clear_dates_params),
+            <%= link_to prefix_path(route_path, clear_dates_params),
               class: "pull-right btn btn-default btn-xs",
               aria_label: t("search.dates.clear_filter",
               default: "Clear Date Filter"), rel: "nofollow", role: "button",

--- a/app/views/items/_facets.html.erb
+++ b/app/views/items/_facets.html.erb
@@ -35,7 +35,7 @@
               <!-- list item -->
               <% if !selected %>
                 <li>
-                  <%= link_to label, prefix_path("search_path",
+                  <%= link_to label, prefix_path(route_path,
                     facet_link(facet_name, key)), rel: "nofollow" %>
                   <span class="badge"><%= value %></span>
                 </li>
@@ -43,7 +43,7 @@
                 <li class="selected">
                   <span><%= label %></span>
                   <span class="badge"><%= value %></span>
-                  <%= link_to prefix_path("search_path",
+                  <%= link_to prefix_path(route_path,
                     remove_facet(facet_name, key)), rel: "nofollow" do %>
                     <button class="btn btn-default btn-xs"
                             title="<%= t("search.filters.clear", label: info['label'], default: "Clear #{info['label']} Filter") %>"

--- a/app/views/items/_search_box.html.erb
+++ b/app/views/items/_search_box.html.erb
@@ -4,7 +4,7 @@
       <div class="panel-body">
         <div class="row">
           <div class="col-md-10">
-            <%= form_tag prefix_path("search_path"), method: "get",
+            <%= form_tag prefix_path(route_path), method: "get",
               class: "input-group" do %>
               <!-- search box -->
               <%= text_field_tag(:q, params[:q], :placeholder => t("search.placeholder", default: "Search for..."), :class => "form-control") %>
@@ -17,11 +17,11 @@
             <% end %>
             <%= render_overridable("items", "help") %>
             <%= link_to t("search.view_all", default: "View All Items"),
-              prefix_path("search_path"), rel: "search" %>
+              prefix_path(route_path), rel: "search" %>
           </div>
           <div class="col-md-2">
             <%= link_to t("search.clear_all", default: "Clear Search"),
-              prefix_path("search_path"),
+              prefix_path(route_path),
               class: "btn btn-danger clear_main_search_text", rel: "search" %>
           </div>
         </div> <!-- /row -->

--- a/app/views/items/_summary_boxes.html.erb
+++ b/app/views/items/_summary_boxes.html.erb
@@ -9,7 +9,7 @@
         <div class="input-group-btn"
              aria-label="<%= t "search.clear_text", default: "Clear Search Text" %>"
              title="<%= t "search.clear_text", default: "Clear Search Text" %>">
-          <%= link_to prefix_path("search_path", clear_search_text),
+          <%= link_to prefix_path(route_path, clear_search_text),
                       class: "btn btn-default btn-sm", rel: "nofollow",
                       role: "button" do %>
             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
@@ -30,7 +30,7 @@
         <div class="input-group-btn"
              title="<%= t "search.dates.clear_filter", default: "Clear Date Filter" %>"
              aria-label="<%= t "search.dates.clear_filter", default: "Clear Date Filter" %>">
-          <%= link_to prefix_path("search_path", clear_dates_params),
+          <%= link_to prefix_path(route_path, clear_dates_params),
             class: "btn btn-default btn-sm", rel: "nofollow",
             role: "button" do %>
             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
@@ -55,7 +55,7 @@
           <div class="input-group-btn"
                title="<%= t("search.filters.clear", label: label, default: "Clear #{label} Filter") %>"
                aria-label="<%= t("search.filters.clear", label: label, default: "Clear #{label} Filter") %>">
-            <%= link_to prefix_path("search_path", remove_facet(type, facet)),
+            <%= link_to prefix_path(route_path, remove_facet(type, facet)),
               class: "btn btn-default btn-sm", rel: "nofollow",
               role: "button" do %>
               <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>

--- a/app/views/items/browse.html.erb
+++ b/app/views/items/browse.html.erb
@@ -1,7 +1,7 @@
 <h1><% t "browse.title", default: "Browse" %></h1>
 
 <p>
-  <%= link_to t("browse.all_link", default: "All Items in the Archive"), prefix_path("search_path"),
+  <%= link_to t("browse.all_link", default: "All Items in the Archive"), prefix_path(route_path),
         class: "btn btn-lg btn-default", rel: "search" %>
 </p>
 

--- a/app/views/items/browse_facet.html.erb
+++ b/app/views/items/browse_facet.html.erb
@@ -50,19 +50,19 @@
               <tr>
                   <% text = list[0].blank? ? t("browse.no_label", default: "No label") : value_label(facet_name, list[0]) %>
                   <td class="index_num">
-                    <%= link_to prefix_path("search_path",
+                    <%= link_to prefix_path(route_path,
                       f: ["#{facet_name}|#{list[0]}"]), rel: "nofollow" do %>
                       <%= list[1] %>
                     <% end %>
                   </td>
                   <td class="index_spacer">
-                    <%= link_to prefix_path("search_path",
+                    <%= link_to prefix_path(route_path,
                       f: ["#{facet_name}|#{list[0]}"]), rel: "nofollow" do %>
                       <span></span>
                     <% end %>
                   </td>
                   <td class="index_name">
-                    <%= link_to prefix_path("search_path",
+                    <%= link_to prefix_path(route_path,
                       f: ["#{facet_name}|#{list[0]}"]), rel: "nofollow" do %>
                       <%= text %>
                     <% end %>


### PR DESCRIPTION
changes "search_path" hardcodes to route_path to allow overrides

tested insofar as an override works for the search_box, and all browse pages / etc
appear to be working normally with default search_path behavior