### PR TITLE
attaches classes to filter selection for easier styling

### DIFF
--- a/app/views/items/_date_limit.html.erb
+++ b/app/views/items/_date_limit.html.erb
@@ -2,7 +2,7 @@
 <% class_in = date_selected ? "in" : "" %>
 <% class_glyphicon = date_selected ? "glyphicon-chevron-down" : "glyphicon-chevron-right" %>
 
-<div class="panel panel-default">
+<div class="panel panel-default panel-filter panel-filter-date">
   <div class="clearfix panel-heading" data-toggle="collapse"
        data-target="#dates" role="Option"
        aria-label="<%= t "search.dates.show_filters", default: "Show Date Filters" %>">

--- a/app/views/items/_facets.html.erb
+++ b/app/views/items/_facets.html.erb
@@ -11,7 +11,7 @@
       <% class_in =  start_open ? "in" : "" %>
       <% class_glyphicon = start_open ? "glyphicon-chevron-down" : "glyphicon-chevron-right" %>
 
-      <div class="panel panel-default">
+      <div class="panel panel-default panel-filter panel-filter-<%= info['label'].parameterize %>">
 
         <!-- panel heading -->
         <div class="clearfix panel-heading" data-toggle="collapse"


### PR DESCRIPTION
this came up when we were working on the African Poetry Digital Portal and found that some sections required a date search while others did not, and found it difficult to select specific filters using CSS.