### PR TITLE
fix language config problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - bug with locales yaml creation
+- es locale file will be copied into app if Spanish requested
 
 ### Added
 - partials for browse, browse_facet, index, and search_preset header content for easier overriding
@@ -44,8 +45,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `language` (head)
 
 ### Changed
-- `ALL_LANGUAGES` setting changed back to `languages`
 - language documentation clarified and expanded
+- references to `APP_OPTS["languages"]` changed to use `all_languages`
+
+### Migration
+- rename `languages` and `ALL_LANGUAGES` to `all_languages` in `public.yml` file
 
 ## [v3.1.0](https://github.com/CDRH/orchid/compare/v3.0.3...v3.1.0) - search_preset, improved section links, and misc display
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - bug with locales yaml creation
 - es locale file will be copied into app if Spanish requested
+- thumbnail size in `public.yml` requires quotation marks for newer psyche yaml gem
 
 ### Added
 - partials for browse, browse_facet, index, and search_preset header content for easier overriding

--- a/app/helpers/orchid/application_helper.rb
+++ b/app/helpers/orchid/application_helper.rb
@@ -182,8 +182,8 @@ module Orchid::ApplicationHelper
   end
 
   def locale_link(lang_code)
-    locales = APP_OPTS["languages"].split("|")
-      .reject { |l| l == APP_OPTS["language_default"] }.join("|")
+    locales = APP_OPTS["all_languages"].split("|")
+      .reject { |l| l == APP_OPTS["all_language_default"] }.join("|")
     url = request.fullpath
 
     if lang_code == APP_OPTS["language_default"]

--- a/app/views/layouts/body/_languages.html.erb
+++ b/app/views/layouts/body/_languages.html.erb
@@ -1,4 +1,4 @@
-<% langs = APP_OPTS["languages"] %>
+<% langs = APP_OPTS["all_languages"] %>
 
 <% if langs.present? && langs[/\|/] %>
   <div class="language_link btn-group" role="group" aria-label="language choice">

--- a/app/views/layouts/head/_language.html.erb
+++ b/app/views/layouts/head/_language.html.erb
@@ -1,6 +1,7 @@
 <%# links for alternate language pages %>
-<% if APP_OPTS["languages"].present? && APP_OPTS["languages"][/\|/] %>
-  <% APP_OPTS["languages"].split("|").each do |lang_code| %>
+<% langs = APP_OPTS["all_languages"] %>
+<% if langs.present? && langs[/\|/] %>
+  <% langs.split("|").each do |lang_code| %>
     <%# if this is the currently selected language
         then no alternative link is needed for it %>
     <% next if lang_code == I18n.locale.to_s %>

--- a/lib/generators/setup_generator.rb
+++ b/lib/generators/setup_generator.rb
@@ -125,6 +125,10 @@ class SetupGenerator < Rails::Generators::Base
     config_set("public", "media_server_dir", answer)
 
     answer = prompt_for_value("Thumbnail Size (default: !200,200)", "!200,200")
+    # due to the exclamation mark, this needs to be surrounded in quotation marks
+    if !answer[/^".*"$/]
+      answer = "\"#{answer}\""
+    end
     config_set("public", "thumbnail_size", answer)
 
     # private config customization

--- a/lib/generators/templates/public.yml
+++ b/lib/generators/templates/public.yml
@@ -9,7 +9,7 @@ default: &default
     # defaults to "en" (english) if no default language set
     language_default: en
     # pipe delineated codes for all languages, e.g. "en|es|cz"
-    ALL_LANGUAGES: en
+    all_languages: en
     # for application title settings, please alter the files in config/locales
 
     # IMAGES

--- a/lib/orchid/routing.rb
+++ b/lib/orchid/routing.rb
@@ -9,8 +9,8 @@ module Orchid
 
       # If multiple languages, constrain locale to non-default language codes
       locales = nil
-      if defined?(APP_OPTS) && APP_OPTS["languages"].present?
-        other_languages = APP_OPTS["languages"].split("|")
+      if defined?(APP_OPTS) && APP_OPTS["all_languages"].present?
+        other_languages = APP_OPTS["all_languages"].split("|")
           .reject { |l| l == APP_OPTS["language_default"] }
 
         if other_languages.present?


### PR DESCRIPTION
OK there are two issues here:

1.  `languages` appeared in multiple places in the public.yml file, but only the first was intended to be configured based on user language preferences during setup.  To mitigate that, this has now been named `all_languages`

2.  The resulting YAML was still invalid because of recent updates to the psyche gem. Now the thumbnail size is surrounded in quotation marks to make this valid