### PR TITLE
catches api error and adds flash warning to affected pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,20 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/CDRH/orchid/compare/v3.1.1...dev) - unreleased
 
+### Fixed
+- displays flash message if API is down, instead of pages throwing errors
+
 ### Changed
 - updates jquery 1.x to 3.x
 - rails g setup is now rails g orchid_setup
+- check_response method added to items_controller
 
 ### Migration
 - modify existing app's `application.js`
   - change `//= require jquery` to `//= require jquery3`
   - apps will continue to function with older jquery if not modified
+  - add `errors.api` and `search.results.error` to locale files
+  - check items_overrides and views/items for changes related to display items when API is unavailable
 
 ## [v3.1.1](https://github.com/CDRH/orchid/compare/v3.1.0...v3.1.1) - splitting templates, fixing languages
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -42,7 +42,7 @@ class ItemsController < ApplicationController
     @res = @items_api.query(options).facets
 
     # Warn when approaching facet result limit
-    result_size = @res.length
+    result_size = @res ? @res.length : 0
     if result_size == 10000
       raise {"Facet results list has hit the limit of 10000. Revisit facet
         result handling NOW"}
@@ -55,6 +55,7 @@ class ItemsController < ApplicationController
     end
 
     @title = "#{t "browse.browse_type"} #{@browse_facet_info["label"]}"
+    check_response
     render_overridable("items", "browse_facet", locals: { sort_by: sort_by })
   end
 
@@ -70,15 +71,23 @@ class ItemsController < ApplicationController
 
     @title = t "search.title"
     @res = @items_api.query(options)
-
+    check_response
     render_overridable("items", "index")
   end
 
   def show
     item_retrieve(params["id"])
+    check_response
   end
 
   private
+
+  # display a flash message if the API response has an error
+  def check_response
+    if !@res || @res.error
+      flash[:error] = t "errors.api"
+    end
+  end
 
   def item_retrieve(id)
     @res = @items_api.get_item_by_id(id).first

--- a/app/services/api_bridge/query.rb
+++ b/app/services/api_bridge/query.rb
@@ -172,7 +172,10 @@ module ApiBridge
         res = Net::HTTP.get_response(URI(url))
         JSON.parse(res.body)
       rescue => e
-        raise "Something went wrong with request to #{url}: #{e.inspect}"
+        Rails.logger.error("Something wrong with API request to #{url}: #{e.inspect}")
+        {
+          "error" => e.inspect
+        }
       end
     end
 

--- a/app/services/api_bridge/response.rb
+++ b/app/services/api_bridge/response.rb
@@ -15,6 +15,10 @@ module ApiBridge
       @res.dig("res", "count")
     end
 
+    def error
+      @res.dig("error")
+    end
+
     def facets
       @res.dig("res", "facets")
     end

--- a/app/views/items/_search_res_count.html.erb
+++ b/app/views/items/_search_res_count.html.erb
@@ -1,4 +1,6 @@
-<% if params["q"].blank? && params["f"].blank? %>
+<% if @res.count.nil? %>
+  <h2><%= t "search.results.error" %></h2>
+<% elsif params["q"].blank? && params["f"].blank? %>
   <h2><%= t "search.results.query", count: @res.count %></h2>
 <% else %>
   <h2><%= t "search.results.general", count: @res.count %></h2>

--- a/app/views/items/_search_res_count.html.erb
+++ b/app/views/items/_search_res_count.html.erb
@@ -1,4 +1,4 @@
-<% if @res.count.nil? %>
+<% if @res.count.blank? %>
   <h2><%= t "search.results.error" %></h2>
 <% elsif params["q"].blank? && params["f"].blank? %>
   <h2><%= t "search.results.query", count: @res.count %></h2>

--- a/app/views/items/_search_res_items.html.erb
+++ b/app/views/items/_search_res_items.html.erb
@@ -1,4 +1,4 @@
-<% if @res.count && @res.count > 0 %>
+<% if @res.present? && @res.count > 0 %>
   <% @res.items.each do |item| %>
     <div class="searchResults buffer-bottom-sm">
       <h3><%= search_item_link(item) %></h3>

--- a/app/views/items/_search_res_items.html.erb
+++ b/app/views/items/_search_res_items.html.erb
@@ -1,4 +1,4 @@
-<% if @res.count > 0 %>
+<% if @res.count && @res.count > 0 %>
   <% @res.items.each do |item| %>
     <div class="searchResults buffer-bottom-sm">
       <h3><%= search_item_link(item) %></h3>

--- a/app/views/items/_sort_and_page_ui.html.erb
+++ b/app/views/items/_sort_and_page_ui.html.erb
@@ -1,6 +1,6 @@
 <div class="row search_controls">
   <div class="col-md-4 search_limit">
-    <% if (@res.count > 1) %>
+    <% if (@res.count && @res.count > 1) %>
       <%= sorter %>
     <% end %>
   </div>

--- a/app/views/items/browse_facet.html.erb
+++ b/app/views/items/browse_facet.html.erb
@@ -43,7 +43,7 @@
     <% id = facet_name.parameterize(separator: ".")  %>
     <div role="tabpanel"
       class="tab-pane <%= active?(facet_name, @browse_facet) %>" id="<%= id %>">
-      <% if @res.key?(facet_name) %>
+      <% if @res && @res.key?(facet_name) %>
         <table class="index_table">
           <tbody>
             <% @res[facet_name].each do |list| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,8 @@ en:
   # ERRORS #
   ##########
   errors:
+    # unable to contact the API
+    api: Some contents of the site are unavailable at this time, please check back later.
     # general consolation message to the user on an error
     apology: We're sorry for the inconvenience.
     # browse page specific message when selected facet cannot be viewed
@@ -219,6 +221,8 @@ en:
     # placeholder for the text search field
     placeholder: Search for...
     results:
+      # display for number of results when API response is error
+      error: Unable to display results
       # how to display number of results when no search / filters have been applied
       # and therefore user is browsing all items
       general:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -80,6 +80,8 @@ es:
   # ERRORS #
   ##########
   errors:
+    # unable to contact API
+    api: Algunos contenidos del sitio no están disponibles. Por favor, vuelva más tarde.
     # general consolation message to the user on an error
     apology: Le pedimos disculpas por la inconveniencia, ocurrió un error.
     # browse page specific message when selected facet cannot be viewed
@@ -218,6 +220,8 @@ es:
     # placeholder for the text search field
     placeholder: Buscar...
     results:
+      # display for number of results when API response is error
+      error: Los resultados no se pueden visualizar
       # how to display number of results when no search / filters have been applied
       # and therefore user is browsing all items
       general:


### PR DESCRIPTION
possibly addresses https://github.com/CDRH/orchid/issues/198

If the API sends an error response (like for example, if it is down entirely), this will create a friendlier message to the user than the entire page crashing and burning.  We may want to consider, possibly as future issues because I really think this is in general a big improvement, trying to pass through different messages depending on whether there was just a bad query vs that the API is down entirely.