### PR TITLE
Fix check response

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -84,7 +84,7 @@ class ItemsController < ApplicationController
 
   # display a flash message if the API response has an error
   def check_response
-    if !@res || @res.error
+    if !@res || (@res.key?("error") && @res.error)
       flash[:error] = t "errors.api"
     end
   end


### PR DESCRIPTION
the check_response method was causing apps to crash if there was no "error" key in the API response hash. Changed the code to check for the presence of the key before checking for the value.