### PR TITLE
Fix handling of check_response 

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,7 +39,9 @@ class ItemsController < ApplicationController
     }
 
     # Get facet results
-    @res = @items_api.query(options).facets
+    @res = @items_api.query(options)
+    check_response
+    @res = @res.facets
 
     # Warn when approaching facet result limit
     result_size = @res ? @res.length : 0
@@ -55,7 +57,6 @@ class ItemsController < ApplicationController
     end
 
     @title = "#{t "browse.browse_type"} #{@browse_facet_info["label"]}"
-    check_response
     render_overridable("items", "browse_facet", locals: { sort_by: sort_by })
   end
 
@@ -83,7 +84,7 @@ class ItemsController < ApplicationController
 
   # display a flash message if the API response has an error
   def check_response
-    if !@res || @res.error
+    if @res.blank? || @res.error
       flash[:error] = t "errors.api"
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -78,6 +78,7 @@ class ItemsController < ApplicationController
   def show
     item_retrieve(params["id"])
     check_response
+    @res = @res.first
   end
 
   private
@@ -90,9 +91,9 @@ class ItemsController < ApplicationController
   end
 
   def item_retrieve(id)
-    @res = @items_api.get_item_by_id(id).first
+    @res = @items_api.get_item_by_id(id)
     if @res
-      url = @res["uri_html"]
+      url = @res.first["uri_html"]
       @html = Net::HTTP.get(URI.parse(url)) if url
       @title = item_title
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -77,8 +77,6 @@ class ItemsController < ApplicationController
 
   def show
     item_retrieve(params["id"])
-    check_response
-    @res = @res.first
   end
 
   private
@@ -92,8 +90,10 @@ class ItemsController < ApplicationController
 
   def item_retrieve(id)
     @res = @items_api.get_item_by_id(id)
+    check_response
+    @res = @res.first
     if @res
-      url = @res.first["uri_html"]
+      url = @res["uri_html"]
       @html = Net::HTTP.get(URI.parse(url)) if url
       @title = item_title
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -84,7 +84,7 @@ class ItemsController < ApplicationController
 
   # display a flash message if the API response has an error
   def check_response
-    if !@res || (@res.key?("error") && @res.error)
+    if !@res || @res.error
       flash[:error] = t "errors.api"
     end
   end


### PR DESCRIPTION
This reverts commit e6be8829116bf9436f7a0ad101dc6da3b858ed9d.
Reverts #229 and fixes #232, since the original error-checking code works under most circumstances.