### PR TITLE
Streamline _search_box partial

### DIFF
--- a/app/assets/stylesheets/orchid.scss
+++ b/app/assets/stylesheets/orchid.scss
@@ -200,7 +200,6 @@ a:focus {
       padding: 0;
       text-decoration: underline;
 
-
       > h2.panel-heading {
         background-color: initial;
         border: none;

--- a/app/assets/stylesheets/orchid.scss
+++ b/app/assets/stylesheets/orchid.scss
@@ -162,28 +162,32 @@ a:focus {
 // =====================
 
 // Search box
-.search_form .searchbox {
+.searchbox {
 
-  .row > div:first-child {
-    margin-bottom: 20px;
-  }
-
-  .panel-heading-link.btn-link {
-    padding: 0;
-    text-decoration: underline;
-
-    &:hover {
-      text-decoration: underline;
-      text-decoration-thickness: 2px;
-    }
-
-    h2 {
-      padding: 0;
-    }
-  }
-
+  // Search field
   .panel-body {
-    padding: 18px;
+
+    .search-text-group {
+      display: flex;
+      flex-wrap: wrap;
+      width: 100%;
+
+      .search-text-field {
+        flex-grow: 1;
+        margin-right: -1px;
+        max-width: 100%;
+      }
+
+      .search-text-button .btn {
+        border-radius: 0;
+      }
+    }
+  }
+
+  // Clear search
+
+  .clear_main_search_text {
+    white-space: initial;
   }
 
   // Search help
@@ -193,18 +197,27 @@ a:focus {
     margin: 0;
 
     .panel-heading-link {
+      border: 0;
+      font-family: $font-family-base;
+      padding: 0;
+      text-decoration: underline;
+
+      &:hover {
+        text-decoration-thickness: 2px;
+      }
 
       > h2.panel-heading {
         background-color: initial;
         border: none;
         border-radius: initial;
         color: inherit; // Use variable for link color
-        display: inline;
+        display: inline-block;
         font-size: 16px;
         margin: 0;
         padding: 0 0 0 5px;
 
         .glyphicon {
+          display: inline-block;
           font-size: 12px;
           margin-left: 5px;
         }
@@ -214,7 +227,7 @@ a:focus {
         }
       }
     }
-    
+
     .panel-body {
       padding: 5px;
 
@@ -239,17 +252,6 @@ a:focus {
   color: $gray-dark;
   background-color: $panel-default-heading-bg;
   border-color: $panel-inner-border;
-}
-
-.searchbox .input-group .form-control:first-child {
-  height: 100%;
-}
-
-.clear_main_search_text {
-  line-height: 1;
-  padding-bottom: 1rem;
-  padding-top: 1rem;
-  white-space: initial;
 }
 
 .panel-filter {

--- a/app/assets/stylesheets/orchid.scss
+++ b/app/assets/stylesheets/orchid.scss
@@ -165,28 +165,26 @@ a:focus {
 .searchbox {
 
   // Search field
-  .panel-body {
+  .search-text-group {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
 
-    .search-text-group {
-      display: flex;
-      flex-wrap: wrap;
-      width: 100%;
+    .search-text-field {
+      flex-grow: 1;
+      margin-right: -1px;
+      max-width: 100%;
+    }
 
-      .search-text-field {
-        flex-grow: 1;
-        margin-right: -1px;
-        max-width: 100%;
-      }
-
-      .search-text-button .btn {
-        border-radius: 0;
-      }
+    .search-text-button .btn {
+      border-radius: 0;
     }
   }
 
   // Clear search
-
   .clear_main_search_text {
+    margin-top: 20px;
+    text-align: right;
     white-space: initial;
   }
 
@@ -194,7 +192,7 @@ a:focus {
   .panel-search-help {
     border: none;
     box-shadow: none;
-    margin: 0;
+    margin: 20px 0px 0px 0px;
 
     .panel-heading-link {
       border: 0;

--- a/app/assets/stylesheets/orchid.scss
+++ b/app/assets/stylesheets/orchid.scss
@@ -200,9 +200,6 @@ a:focus {
       padding: 0;
       text-decoration: underline;
 
-      &:hover {
-        text-decoration-thickness: 2px;
-      }
 
       > h2.panel-heading {
         background-color: initial;
@@ -222,7 +219,12 @@ a:focus {
 
         .panel-title {
           font-size: inherit;
+          text-decoration: underline;
         }
+      }
+
+      &:hover > h2.panel-heading .panel-title {
+        text-decoration-thickness: 2px;
       }
     }
 

--- a/app/views/items/_search_box.html.erb
+++ b/app/views/items/_search_box.html.erb
@@ -5,24 +5,25 @@
         <div class="row">
           <div class="col-md-12">
             <%= form_tag prefix_path(route_path), method: "get", role: "search", 
-              class: "input-group" do %>
+              class: "search-text-group" do %>
               <%# search box %>
-              <%= text_field_tag(:q, params[:q], :placeholder => t("search.placeholder", default: "Search for..."), :class => "form-control", aria: { label: "Search" }) %>
+              <%= text_field_tag(:q, params[:q], :placeholder => t("search.placeholder", default: "Search for..."), :class => "search-text-field", aria: { label: "Search" }) %>
               <%# add existing search parameters to query %>
               <%= render_overridable("items", "hidden_fields") %>
               <%# submit %>
-              <span class="input-group-btn">
+              <span class="search-text-button">
                 <%= submit_tag t("search.submit", default: "Search"), class: "btn btn-primary", name: nil, data: { disable_with: false } %>
               </span>
             <% end %>
           </div>
-          <div class="col-xs-8">
+          <div class="col-xs-9 col-md-8">
             <%= render_overridable("items", "help") %>
           </div>
-          <div class="col-xs-4 text-right">
+          <div class="col-xs-3 col-md-4 text-right">
+           <div class="clear_main_search_text">
             <%= link_to t("search.clear_all", default: "Reset Search"),
-              prefix_path(route_path),
-              class: "clear_main_search_text", rel: "search" %>
+              prefix_path(route_path), rel: "search" %>
+            </div>
           </div>
         </div> <%# /row %>
       </div> <%# /panel-body %>

--- a/app/views/items/_search_box.html.erb
+++ b/app/views/items/_search_box.html.erb
@@ -16,10 +16,10 @@
               </span>
             <% end %>
           </div>
-          <div class="col-xs-9 col-md-8">
+          <div class="col-xs-9 col-sm-8">
             <%= render_overridable("items", "help") %>
           </div>
-          <div class="col-xs-3 col-md-4 text-right">
+          <div class="col-xs-3 col-sm-4">
            <div class="clear_main_search_text">
             <%= link_to t("search.clear_all", default: "Reset Search"),
               prefix_path(route_path), rel: "search" %>


### PR DESCRIPTION
- Streamlines the searchbox layout by using a shorter list of custom styles instead of the style-heavy Bootstrap `input-group` classes. This should make it less disruptive when deployed to our already-published sites, and it also fixes the problem where the input was shorter in height than the button.
- Fixes missing underline and double underline on hover for the "Search Help > " link (which I missed the first time around—it needs to be distinguishable from regular text by more than just color.